### PR TITLE
Absolute logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/_static/logo.png" width="200" alt="django-jsonform icon">
+  <img src="https://github.com/bhch/django-jsonform/raw/master/docs/_static/logo.png" width="200" alt="django-jsonform icon">
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/bhch/django-jsonform/raw/master/docs/_static/logo.png" width="200" alt="django-jsonform icon">
+  <img src="https://raw.githubusercontent.com/bhch/django-jsonform/master/docs/_static/logo.png" width="200" alt="django-jsonform icon">
 </p>
 
 <p align="center">


### PR DESCRIPTION
Should fix the issue with logo not displaying when rendered outside of github, for instance PyPi