### PR TITLE
Use `DOMContentLoaded` listener on `document` instead of `window`

### DIFF
--- a/django_jsonform/static/django_jsonform/index.js
+++ b/django_jsonform/static/django_jsonform/index.js
@@ -1,5 +1,5 @@
 (function() {
-  window.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('DOMContentLoaded', function() {
     var _initializedCache = [];
 
     function initJSONForm(element) {


### PR DESCRIPTION
## Issue:
https://github.com/bhch/django-jsonform/issues/79

## Description:
Prevent widget initialization issues in case another script prevents the `DOMContentLoaded` event from bubbling to the window object.
