### PR TITLE
Add test running with Github Actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = True
+source = django_jsonform
+omit = *tests*,__main__

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+name: django-jsonform tests
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        django-version: ["2.2", "3.2", "4.1", "4.2", "main"]
+        exclude:
+          - django-version: 2.2
+            python-version: 3.10
+          - django-version: 2.2
+            python-version: 3.11
+          - django-version: 3.2
+            python-version: 3.11
+          - django-version: 4.1
+            python-version: 3.7
+          - django-version: 4.2
+            python-version: 3.7
+          - django-version: "main"
+            python-version: 3.7
+          - django-version: "main"
+            python-version: 3.8
+          - django-version: "main"
+            python-version: 3.9
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install Django ${{ matrix.django-version }}
+        run: python -m pip install django~=${{ matrix.django-version }}.0
+        if: matrix.django-version != 'main'
+      - name: Install Django main
+        run: python -m pip install https://github.com/django/django/archive/refs/heads/main.zip
+        if: matrix.django-version == 'main'
+      - name: Install library to run tests
+        run: python -m pip install -e .
+      - name: Verify versions
+        run: |
+          python --version
+          python -c "import django ; print(django.VERSION)"
+      - name: Run tests
+        run: |
+          python -m pip install coverage
+          coverage run tests/__main__.py
+          coverage report -m

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -2,7 +2,6 @@ import os
 import sys
 import unittest
 import django
-import django_settings
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -1,8 +1,17 @@
+SECRET_KEY = "secret for test"
+
 ROOT_URLCONF='django_jsonform.urls'
 
 INSTALLED_APPS=[
     'django_jsonform',
 ]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ":memory:",
+    },
+}
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Adds Github actions to run tests with different version: Python 3.7 - 3.11 and Django 2.2 - main
Also adds coverage report at the end but there is no check for the actual results.

Seems like a run takes around 5 billing minutes: https://github.com/kviktor/django-jsonform/actions/runs/4713077105/usage?pr=1 (Github offers 2000 minutes a month for free). The `main` takes a bit longer as it has to download the Django repo from github as zip and the Django 2.2 ones could be removed when support for that Django version is dropped.

For Django 2.2 tests also had to add some extra settings to settings.