### PR TITLE
Fix references to JSONFormField

### DIFF
--- a/docs/fields-and-widgets.rst
+++ b/docs/fields-and-widgets.rst
@@ -143,8 +143,8 @@ Form fields
 
 .. _form-jsonfield:
 
-``JSONField``
-~~~~~~~~~~~~~
+``JSONFormField``
+~~~~~~~~~~~~~~~~~
 
 .. class:: JSONFormField(schema=None, model_name='', field_name='', **options)
     

--- a/docs/fields-and-widgets.rst
+++ b/docs/fields-and-widgets.rst
@@ -146,7 +146,7 @@ Form fields
 ``JSONField``
 ~~~~~~~~~~~~~
 
-.. class:: JSONField(schema=None, model_name='', field_name='', **options)
+.. class:: JSONFormField(schema=None, model_name='', field_name='', **options)
     
 .. versionadded:: 2.0
 
@@ -181,10 +181,10 @@ Usage:
 
 .. code-block:: python
 
-    from django_jsonform.forms.fields import JSONField
+    from django_jsonform.forms.fields import JSONFormField
 
     class MyForm(forms.Form):
-        my_field = JSONField(schema=schema)
+        my_field = JSONFormField(schema=schema)
 
 Widgets
 -------


### PR DESCRIPTION
The form field's name is `JSONFormField`, not `JSONField`.