### PR TITLE
Add missing UUID import

### DIFF
--- a/django_jsonform/forms/fields.py
+++ b/django_jsonform/forms/fields.py
@@ -1,4 +1,6 @@
 import json
+from uuid import UUID
+
 import django
 from django.db import models
 from django.conf import settings

--- a/django_jsonform/forms/fields.py
+++ b/django_jsonform/forms/fields.py
@@ -1,6 +1,5 @@
 import json
 from uuid import UUID
-
 import django
 from django.db import models
 from django.conf import settings


### PR DESCRIPTION
The fix introduced in https://github.com/bhch/django-jsonform/pull/138 is missing the UUID import, rendering the fix non-functional.

`NameError: name 'UUID' is not defined`

This PR adds the missing import.

Apologies for introducing this bug.