### PR TITLE
use DjangoJSONEncoder on ArrayFormField to support datetime, UUID, Decimal, etc.

### DIFF
--- a/django_jsonform/forms/fields.py
+++ b/django_jsonform/forms/fields.py
@@ -1,9 +1,9 @@
 import json
-from uuid import UUID
 import django
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django_jsonform.utils import _get_django_version
 
 django_major, django_minor = _get_django_version()
@@ -75,15 +75,6 @@ class JSONFormField(DjangoJSONFormField):
         self.widget.add_error(error_map)
 
 
-class UUIDCompatibleEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, UUID):
-            return str(obj)
-        elif isinstance(obj, Decimal):
-            return float(obj)
-        return json.JSONEncoder.default(self, obj)
-
-
 class ArrayFormField(SimpleArrayField):
     def __init__(self, base_field, **kwargs):
         if hasattr(SimpleArrayField, 'mock_field'):
@@ -105,7 +96,7 @@ class ArrayFormField(SimpleArrayField):
 
     def prepare_value(self, value):
         if isinstance(value, list):
-            return json.dumps(value, cls=UUIDCompatibleEncoder)
+            return json.dumps(value, cls=DjangoJSONEncoder)
         return value
 
     def to_python(self, value):

--- a/django_jsonform/forms/fields.py
+++ b/django_jsonform/forms/fields.py
@@ -79,6 +79,8 @@ class UUIDCompatibleEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, UUID):
             return str(obj)
+        if isinstance(obj, Decimal):
+            return float(obj)
         return json.JSONEncoder.default(self, obj)
 
 

--- a/django_jsonform/forms/fields.py
+++ b/django_jsonform/forms/fields.py
@@ -79,7 +79,7 @@ class UUIDCompatibleEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, UUID):
             return str(obj)
-        if isinstance(obj, Decimal):
+        elif isinstance(obj, Decimal):
             return float(obj)
         return json.JSONEncoder.default(self, obj)
 


### PR DESCRIPTION
current JSONEncoder would throw "Object of type Decimal is not JSON serializable" if you are using the libraries' ArrayField with a base_field of models.DecimalField().
This is a fix for that.

`from django_jsonform.models.fields import ArrayField`
`example = ArrayField(models.DecimalField(decimal_places=2, max_digits=5))`