### PR TITLE
Enable whitespace selection in choices

### DIFF
--- a/django_jsonform/validators.py
+++ b/django_jsonform/validators.py
@@ -296,9 +296,13 @@ class JSONSchemaValidator:
 
     def validate_string(self, schema, data, coords, raise_exc=False):
         if isinstance(data, str):
-            data = data.strip()
+            trimmed_data = data.strip()
+        else:
+            trimmed_data = data
 
-        if schema.get('required') and not data:
+        is_empty = not trimmed_data
+
+        if schema.get('required') and is_empty:
             self.add_error(coords, 'This field is required.', raise_exc=raise_exc)
             return
 
@@ -306,7 +310,7 @@ class JSONSchemaValidator:
             self.add_error(coords, 'This value is invalid. Must be a valid string.', raise_exc=raise_exc)
             return
 
-        if not data:
+        if is_empty:
             # data not required and is empty
             return
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1226,9 +1226,9 @@ class TestJSONSchemaValidator(TestCase):
         validator(data)
 
         # 7. test choices
-        schema['properties']['a']['choices'] = ['one', 'two']
+        schema['properties']['a']['choices'] = ['one', 'two ']
         wrong_data = {'a': 'xxx'}
-        data = {'a': 'two'}
+        data = {'a': 'two '}  # White space in choices is valid
         self.assertRaises(JSONSchemaValidationError, validator, wrong_data)
         validator(data)
 


### PR DESCRIPTION
A string type with a choice that contains whitespace on the outer part cannot be selected, or it will generate an error. See the modified test for an example.

To fix this, I utilize the stripped/trimmed version of the string value only for validating whether the field is empty, otherwise the raw value is used.